### PR TITLE
Migrate text generation to Codex OAuth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,3 @@
 DISCORD_TOKEN=your_discord_token_here
 GEMINI_API_KEY=your_gemini_api_key_here
 DISCORD_APPLICATION_ID=your_discord_application_id_here
-CODEX_MODEL=gpt-5.5

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 DISCORD_TOKEN=your_discord_token_here
 GEMINI_API_KEY=your_gemini_api_key_here
 DISCORD_APPLICATION_ID=your_discord_application_id_here
+CODEX_MODEL=gpt-5.5

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,13 +25,24 @@ FROM node:25-slim AS runtime
 # Set the working directory
 WORKDIR /app
 
+ENV HOME=/app
+ENV LANGCHAINJS_CODEX_OAUTH_HOME=/app/.langchainjs-codex-oauth
+ENV PATH="/app/node_modules/.bin:${PATH}"
+
 # Create a non-root user and group for security
-RUN groupadd -r appgroup && useradd -r -g appgroup appuser
+RUN groupadd -r appgroup && useradd -r -g appgroup -d /app appuser
 
 # Copy built application
 COPY --from=builder /usr/src/slowpoke/dist /app/dist
 COPY --from=builder /usr/src/slowpoke/node_modules /app/node_modules
 COPY --from=builder /usr/src/slowpoke/package.json /app/package.json
+
+# Keep credentials out of the image. This empty directory is where a runtime
+# Docker volume should be mounted so OAuth refreshes persist across deploys.
+RUN mkdir -p /app/.langchainjs-codex-oauth
+
+# Verify npm/npx are available for one-time auth bootstrapping in the container.
+RUN npm --version && npx --version
 
 # Change ownership to non-root user
 RUN chown -R appuser:appgroup /app

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ slowpoke is a Discord bot converted from Rust to TypeScript, named after the Pok
    - `DISCORD_TOKEN`: Your Discord bot token
    - `GEMINI_API_KEY`: Your Google Gemini API key for image commands
    - `DISCORD_APPLICATION_ID`: Your Discord application ID
-   - `CODEX_MODEL`: Optional Codex model name, defaults to `gpt-5.5`
 
 4. Authenticate Codex text generation once on the machine running the bot:
    ```bash
@@ -48,7 +47,6 @@ services:
     image: ghcr.io/jeph/slowpoke:latest
     environment:
       LANGCHAINJS_CODEX_OAUTH_HOME: /app/.langchainjs-codex-oauth
-      CODEX_MODEL: gpt-5.5
     volumes:
       - slowpoke-codex-oauth:/app/.langchainjs-codex-oauth
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ slowpoke is a Discord bot converted from Rust to TypeScript, named after the Pok
 
 ## Features
 
-- **Chat**: Engage in conversations with the bot using Google's Gemini AI
+- **Chat**: Engage in conversations with the bot using Codex through LangChainJS
 - **Prompt**: Ask questions and get AI-powered responses
 - **Image Generation**: Create images from text prompts using Gemini Imagen
 - **Image Remix**: Transform existing images with AI
@@ -26,7 +26,51 @@ slowpoke is a Discord bot converted from Rust to TypeScript, named after the Pok
 
 3. Fill in your environment variables:
    - `DISCORD_TOKEN`: Your Discord bot token
-   - `GEMINI_API_KEY`: Your Google Gemini API key
+   - `GEMINI_API_KEY`: Your Google Gemini API key for image commands
+   - `DISCORD_APPLICATION_ID`: Your Discord application ID
+   - `CODEX_MODEL`: Optional Codex model name, defaults to `gpt-5.5`
+
+4. Authenticate Codex text generation once on the machine running the bot:
+   ```bash
+   pnpm run codex:auth:login
+   pnpm run codex:auth:status
+   ```
+
+   Codex OAuth credentials are stored by `langchainjs-codex-oauth` outside the app source tree by default. Treat the auth file as a secret.
+
+## Docker Auth
+
+The public Docker image does not include Codex OAuth credentials. Mount a persistent volume at `/app/.langchainjs-codex-oauth` and authenticate once against that volume.
+
+```yaml
+services:
+  slowpoke:
+    image: ghcr.io/jeph/slowpoke:latest
+    environment:
+      LANGCHAINJS_CODEX_OAUTH_HOME: /app/.langchainjs-codex-oauth
+      CODEX_MODEL: gpt-5.5
+    volumes:
+      - slowpoke-codex-oauth:/app/.langchainjs-codex-oauth
+
+volumes:
+  slowpoke-codex-oauth:
+    name: slowpoke-codex-oauth
+```
+
+Bootstrap auth with the same image and volume:
+
+```bash
+docker compose run --rm -it slowpoke npm run codex:auth:login -- --manual
+docker compose run --rm slowpoke npm run codex:auth:status
+```
+
+`npx` is available in the container too:
+
+```bash
+docker compose run --rm -it slowpoke npx langchainjs-codex-oauth auth status
+```
+
+Named volumes persist across image pulls and container recreation. Do not run `docker compose down -v`, remove the volume in Portainer, or prune volumes unless you intend to delete the stored OAuth credentials.
 
 ## Development
 

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -9,3 +9,11 @@ services:
       DISCORD_TOKEN: "your_actual_discord_token_here"
       GEMINI_API_KEY: "your_actual_gemini_api_key_here"
       DISCORD_APPLICATION_ID: "your_actual_discord_application_id_here"
+      CODEX_MODEL: "gpt-5.5"
+      LANGCHAINJS_CODEX_OAUTH_HOME: "/app/.langchainjs-codex-oauth"
+    volumes:
+      - slowpoke-codex-oauth:/app/.langchainjs-codex-oauth
+
+volumes:
+  slowpoke-codex-oauth:
+    name: slowpoke-codex-oauth

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -9,7 +9,6 @@ services:
       DISCORD_TOKEN: "your_actual_discord_token_here"
       GEMINI_API_KEY: "your_actual_gemini_api_key_here"
       DISCORD_APPLICATION_ID: "your_actual_discord_application_id_here"
-      CODEX_MODEL: "gpt-5.5"
       LANGCHAINJS_CODEX_OAUTH_HOME: "/app/.langchainjs-codex-oauth"
     volumes:
       - slowpoke-codex-oauth:/app/.langchainjs-codex-oauth

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "start": "node dist/main.js",
     "dev": "tsx src/main.ts",
     "clean": "rm -rf dist",
+    "codex:auth:login": "langchainjs-codex-oauth auth login",
+    "codex:auth:logout": "langchainjs-codex-oauth auth logout",
+    "codex:auth:status": "langchainjs-codex-oauth auth status",
     "prebuild": "pnpm run clean && pnpm run lint",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"
@@ -22,9 +25,11 @@
   "license": "ISC",
   "dependencies": {
     "@google/genai": "^1.42.0",
+    "@langchain/core": "^1.1.42",
     "@langchain/textsplitters": "^1.0.1",
     "discord.js": "^14.25.1",
     "dotenv": "^17.3.1",
+    "langchainjs-codex-oauth": "^0.1.7",
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,15 +11,21 @@ importers:
       '@google/genai':
         specifier: ^1.42.0
         version: 1.42.0
+      '@langchain/core':
+        specifier: ^1.1.42
+        version: 1.1.42
       '@langchain/textsplitters':
         specifier: ^1.0.1
-        version: 1.0.1(@langchain/core@1.1.8)
+        version: 1.0.1(@langchain/core@1.1.42)
       discord.js:
         specifier: ^14.25.1
         version: 14.25.1
       dotenv:
         specifier: ^17.3.1
         version: 17.3.1
+      langchainjs-codex-oauth:
+        specifier: ^0.1.7
+        version: 0.1.7(@langchain/core@1.1.42)
       pino:
         specifier: ^10.3.1
         version: 10.3.1
@@ -306,8 +312,8 @@ packages:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
-  '@langchain/core@1.1.8':
-    resolution: {integrity: sha512-kIUidOgc0ZdyXo4Ahn9Zas+OayqOfk4ZoKPi7XaDipNSWSApc2+QK5BVcjvwtzxstsNOrmXJiJWEN6WPF/MvAw==}
+  '@langchain/core@1.1.42':
+    resolution: {integrity: sha512-d0tN96BrwPMryYyWR9VfyAntSivn7EQrZCe5Kpxum93tcjTXbKKmKvItFec8AluQt88iTcmAJrahUZUNfzGwTA==}
     engines: {node: '>=20'}
 
   '@langchain/textsplitters@1.0.1':
@@ -364,6 +370,9 @@ packages:
   '@sapphire/snowflake@3.5.3':
     resolution: {integrity: sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==}
     engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
@@ -795,6 +804,13 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
+  langchainjs-codex-oauth@0.1.7:
+    resolution: {integrity: sha512-apuCGiAF12bK+N6/6Ooo8rmC8b/HiVLnAY5mwCWt81FZS2BUqa88pPR5fcOzL8y/ehBJ50fDNamQvChchuiLvQ==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@langchain/core': ^1.1.31
+
   langsmith@0.5.6:
     resolution: {integrity: sha512-T/RA2l2MsTYX0z1aW8rQ2hBQZEOuXV2v/6tkfG6R5EotJTKMpw1dERCbvP8ezOP8otyWfnNlQA88ZnMRsQ7CHA==}
     peerDependencies:
@@ -1083,6 +1099,7 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   web-streams-polyfill@3.3.3:
@@ -1127,6 +1144,9 @@ packages:
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+  zod@4.4.1:
+    resolution: {integrity: sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==}
 
 snapshots:
 
@@ -1324,9 +1344,10 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
-  '@langchain/core@1.1.8':
+  '@langchain/core@1.1.42':
     dependencies:
       '@cfworker/json-schema': 4.1.1
+      '@standard-schema/spec': 1.1.0
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
@@ -1334,7 +1355,6 @@ snapshots:
       langsmith: 0.5.6
       mustache: 4.2.0
       p-queue: 6.6.2
-      uuid: 10.0.0
       zod: 4.3.6
     transitivePeerDependencies:
       - '@opentelemetry/api'
@@ -1342,9 +1362,9 @@ snapshots:
       - '@opentelemetry/sdk-trace-base'
       - openai
 
-  '@langchain/textsplitters@1.0.1(@langchain/core@1.1.8)':
+  '@langchain/textsplitters@1.0.1(@langchain/core@1.1.42)':
     dependencies:
-      '@langchain/core': 1.1.8
+      '@langchain/core': 1.1.42
       js-tiktoken: 1.0.21
 
   '@pinojs/redact@0.4.0': {}
@@ -1383,6 +1403,8 @@ snapshots:
       lodash: 4.17.23
 
   '@sapphire/snowflake@3.5.3': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@types/esrecurse@4.3.1': {}
 
@@ -1872,6 +1894,11 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
+  langchainjs-codex-oauth@0.1.7(@langchain/core@1.1.42):
+    dependencies:
+      '@langchain/core': 1.1.42
+      zod: 4.4.1
+
   langsmith@0.5.6:
     dependencies:
       '@types/uuid': 10.0.0
@@ -2176,3 +2203,5 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   zod@4.3.6: {}
+
+  zod@4.4.1: {}

--- a/src/chime-ins/deez-nuts.ts
+++ b/src/chime-ins/deez-nuts.ts
@@ -1,7 +1,7 @@
 import { Message } from 'discord.js'
 import { ChimeIn } from '../models/chime-in'
-import { GeminiClient } from '../utils/gemini-client'
 import { logger } from '../utils/logger'
+import { TextGenerationClient } from '../utils/text-generation-client'
 
 export interface DeezNutsConfig {
   chimeInProbability: number
@@ -29,7 +29,7 @@ const SYSTEM_INSTRUCTION = 'You are a creative Discord bot that makes "deez nuts
     'Response: No good joke.\n\n' +
     'When returning the response, do not include any additional text or formatting. Just return the joke itself.'
 
-export const createDeezNutsChimeIn = (geminiClient: GeminiClient, config: DeezNutsConfig): ChimeIn => ({
+export const createDeezNutsChimeIn = (textGenerationClient: TextGenerationClient, config: DeezNutsConfig): ChimeIn => ({
   name: 'deez-nuts',
 
   async execute (message: Message): Promise<boolean> {
@@ -39,7 +39,7 @@ export const createDeezNutsChimeIn = (geminiClient: GeminiClient, config: DeezNu
       }
       logger.info('Starting deez nuts chime-in')
 
-      const response = await geminiClient.prompt({
+      const response = await textGenerationClient.prompt({
         systemInstruction: SYSTEM_INSTRUCTION,
         prompt: `User message: "${message.content}"`
       })

--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -1,8 +1,8 @@
 import { SlashCommandBuilder, ChatInputCommandInteraction, DiscordAPIError, Message, Guild } from 'discord.js'
-import { GeminiClient } from '../utils/gemini-client'
 import { logger } from '../utils/logger'
 import { SlashCommand } from '../models/commands'
 import { RecursiveCharacterTextSplitter } from '@langchain/textsplitters'
+import { TextGenerationClient } from '../utils/text-generation-client'
 
 const CHAT_SYSTEM_INSTRUCTION = `You are a Discord bot named slowpoke. You are named after
 the Pokémon Slowpoke. Respond to the Discord messages in the channel. You will be able to see up to
@@ -70,7 +70,7 @@ literally), here are some general guidelines on how to respond:
 
 `
 
-export const createChatCommand = (geminiClient: GeminiClient): SlashCommand => ({
+export const createChatCommand = (textGenerationClient: TextGenerationClient): SlashCommand => ({
   command: new SlashCommandBuilder()
     .setName('chat')
     .setDescription('Chat with slowpoke'),
@@ -100,7 +100,7 @@ export const createChatCommand = (geminiClient: GeminiClient): SlashCommand => (
       }).join('\n')
       logger.info({ formattedMessages }, 'Formatted recent messages for LLM')
 
-      const response = await geminiClient.prompt({
+      const response = await textGenerationClient.prompt({
         prompt: formattedMessages,
         systemInstruction: CHAT_SYSTEM_INSTRUCTION
       })

--- a/src/commands/prompt.ts
+++ b/src/commands/prompt.ts
@@ -1,11 +1,11 @@
 import { SlashCommandBuilder, ChatInputCommandInteraction, EmbedBuilder } from 'discord.js'
 import { RecursiveCharacterTextSplitter } from '@langchain/textsplitters'
-import { GeminiClient } from '../utils/gemini-client'
 import { logger } from '../utils/logger'
 import { SlashCommand } from '../models/commands'
 import { ColorProvider } from '../utils/color-provider'
+import { TextGenerationClient } from '../utils/text-generation-client'
 
-export const createPromptCommand = (geminiClient: GeminiClient, colorProvider: ColorProvider): SlashCommand => {
+export const createPromptCommand = (textGenerationClient: TextGenerationClient, colorProvider: ColorProvider): SlashCommand => {
   return {
     command: new SlashCommandBuilder()
       .setName('prompt')
@@ -29,7 +29,7 @@ export const createPromptCommand = (geminiClient: GeminiClient, colorProvider: C
           return
         }
 
-        const response = await geminiClient.prompt({
+        const response = await textGenerationClient.prompt({
           prompt: promptText,
           systemInstruction: PROMPT_SYSTEM_INSTRUCTION
         })

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { Client, Events, GatewayIntentBits, Partials } from 'discord.js'
 import dotenv from 'dotenv'
 import { GoogleGenAI } from '@google/genai'
 import { createGeminiClient } from './utils/gemini-client'
+import { createCodexTextClient } from './utils/codex-text-client'
 import { startActivityRotation } from './utils/activity-manager'
 import { logger } from './utils/logger'
 import { createCommandRegistrar } from './utils/command-registrar'
@@ -46,16 +47,18 @@ logger.info('Successfully got gemini api key from environment')
 const googleGenAI = new GoogleGenAI({ apiKey: geminiApiKey })
 const geminiClient = createGeminiClient({
   googleGenAI,
-  textGenerationModel: 'gemini-3-flash-preview',
   imageGenerationModel: 'gemini-2.0-flash-preview-image-generation'
 })
+const codexModel = process.env.CODEX_MODEL ?? 'gpt-5.5'
+logger.info({ model: codexModel, serviceTier: 'priority' }, 'Configuring Codex text client')
+const textGenerationClient = createCodexTextClient({ model: codexModel })
 const colorProvider = createColorProvider()
 
 const slashCommandList: SlashCommand[] = [
   createPingCommand(colorProvider),
   createEightBallCommand(colorProvider),
-  createPromptCommand(geminiClient, colorProvider),
-  createChatCommand(geminiClient),
+  createPromptCommand(textGenerationClient, colorProvider),
+  createChatCommand(textGenerationClient),
   createTftiCommand(colorProvider),
   createImagineCommand(geminiClient, colorProvider),
   createRollCommand(colorProvider)
@@ -105,7 +108,7 @@ client.on(Events.InteractionCreate, async (interaction) => {
   }
 })
 
-const deezNutsChimeIn = createDeezNutsChimeIn(geminiClient, { chimeInProbability: 0.01 })
+const deezNutsChimeIn = createDeezNutsChimeIn(textGenerationClient, { chimeInProbability: 0.01 })
 
 client.on(Events.MessageCreate, async (message) => {
   if (message.author.bot) return

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,9 +49,8 @@ const geminiClient = createGeminiClient({
   googleGenAI,
   imageGenerationModel: 'gemini-2.0-flash-preview-image-generation'
 })
-const codexModel = process.env.CODEX_MODEL ?? 'gpt-5.5'
-logger.info({ model: codexModel, serviceTier: 'priority' }, 'Configuring Codex text client')
-const textGenerationClient = createCodexTextClient({ model: codexModel })
+logger.info({ model: 'gpt-5.5', serviceTier: 'priority' }, 'Configuring Codex text client')
+const textGenerationClient = createCodexTextClient()
 const colorProvider = createColorProvider()
 
 const slashCommandList: SlashCommand[] = [

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,7 +49,7 @@ const geminiClient = createGeminiClient({
   googleGenAI,
   imageGenerationModel: 'gemini-2.0-flash-preview-image-generation'
 })
-logger.info({ model: 'gpt-5.5', serviceTier: 'priority' }, 'Configuring Codex text client')
+logger.info({ model: 'gpt-5.5', reasoningEffort: 'medium', serviceTier: 'priority' }, 'Configuring Codex text client')
 const textGenerationClient = createCodexTextClient()
 const colorProvider = createColorProvider()
 

--- a/src/utils/codex-text-client.ts
+++ b/src/utils/codex-text-client.ts
@@ -8,13 +8,14 @@ const CODEX_MODEL = 'gpt-5.5'
 export const createCodexTextClient = (): TextGenerationClient => {
   const chatModel = new ChatCodexOAuth({
     model: CODEX_MODEL,
+    reasoningEffort: 'medium',
     serviceTier: 'priority'
   })
 
   return {
     async prompt (options: PromptOptions): Promise<string> {
       const { prompt, systemInstruction } = options
-      logger.info({ prompt, systemInstruction, model: CODEX_MODEL, serviceTier: 'priority' }, 'Sending prompt to Codex')
+      logger.info({ prompt, systemInstruction, model: CODEX_MODEL, reasoningEffort: 'medium', serviceTier: 'priority' }, 'Sending prompt to Codex')
 
       const messages = systemInstruction
         ? [new SystemMessage(systemInstruction), new HumanMessage(prompt)]

--- a/src/utils/codex-text-client.ts
+++ b/src/utils/codex-text-client.ts
@@ -1,0 +1,38 @@
+import { HumanMessage, SystemMessage } from '@langchain/core/messages'
+import { ChatCodexOAuth } from 'langchainjs-codex-oauth'
+import { logger } from './logger'
+import { PromptOptions, TextGenerationClient } from './text-generation-client'
+
+export interface CodexTextClientOptions {
+  model: string;
+}
+
+export const createCodexTextClient = (options: CodexTextClientOptions): TextGenerationClient => {
+  const { model } = options
+  const chatModel = new ChatCodexOAuth({
+    model,
+    serviceTier: 'priority'
+  })
+
+  return {
+    async prompt (options: PromptOptions): Promise<string> {
+      const { prompt, systemInstruction } = options
+      logger.info({ prompt, systemInstruction, model, serviceTier: 'priority' }, 'Sending prompt to Codex')
+
+      const messages = systemInstruction
+        ? [new SystemMessage(systemInstruction), new HumanMessage(prompt)]
+        : [new HumanMessage(prompt)]
+
+      const response = await chatModel.invoke(messages)
+      const text = response.text
+
+      if (!text) {
+        logger.error({ response }, 'No text returned from Codex')
+        throw new Error('No text was returned from the LLM via inference')
+      }
+
+      logger.info({ text }, 'Received response from Codex')
+      return text
+    }
+  }
+}

--- a/src/utils/codex-text-client.ts
+++ b/src/utils/codex-text-client.ts
@@ -3,21 +3,18 @@ import { ChatCodexOAuth } from 'langchainjs-codex-oauth'
 import { logger } from './logger'
 import { PromptOptions, TextGenerationClient } from './text-generation-client'
 
-export interface CodexTextClientOptions {
-  model: string;
-}
+const CODEX_MODEL = 'gpt-5.5'
 
-export const createCodexTextClient = (options: CodexTextClientOptions): TextGenerationClient => {
-  const { model } = options
+export const createCodexTextClient = (): TextGenerationClient => {
   const chatModel = new ChatCodexOAuth({
-    model,
+    model: CODEX_MODEL,
     serviceTier: 'priority'
   })
 
   return {
     async prompt (options: PromptOptions): Promise<string> {
       const { prompt, systemInstruction } = options
-      logger.info({ prompt, systemInstruction, model, serviceTier: 'priority' }, 'Sending prompt to Codex')
+      logger.info({ prompt, systemInstruction, model: CODEX_MODEL, serviceTier: 'priority' }, 'Sending prompt to Codex')
 
       const messages = systemInstruction
         ? [new SystemMessage(systemInstruction), new HumanMessage(prompt)]

--- a/src/utils/gemini-client.ts
+++ b/src/utils/gemini-client.ts
@@ -1,21 +1,13 @@
 import { GoogleGenAI, Modality, GenerateContentResponse } from '@google/genai'
-import { logger } from './logger'
 
 export interface GeminiClient {
-  prompt(prompt: PromptOptions): Promise<string>;
   generateImage(options: GenerateImageOptions): Promise<Buffer>;
   editImage(options: EditImageOptions): Promise<Buffer>;
 }
 
 export interface GeminiClientOptions {
   googleGenAI: GoogleGenAI;
-  textGenerationModel: string;
   imageGenerationModel: string;
-}
-
-export interface PromptOptions {
-  systemInstruction: string | undefined;
-  prompt: string;
 }
 
 export interface GenerateImageOptions {
@@ -29,30 +21,8 @@ export interface EditImageOptions {
 }
 
 export const createGeminiClient = (options: GeminiClientOptions): GeminiClient => {
-  const { googleGenAI, textGenerationModel, imageGenerationModel } = options
+  const { googleGenAI, imageGenerationModel } = options
   return {
-    async prompt (options: PromptOptions): Promise<string> {
-      const { prompt, systemInstruction } = options
-      logger.info({ prompt, systemInstruction }, 'Sending prompt to Gemini')
-      const response = await googleGenAI.models.generateContent(
-        {
-          model: textGenerationModel,
-          contents: prompt,
-          config: {
-            systemInstruction
-          }
-        }
-      )
-
-      if (!response.text) {
-        logger.error({ response }, 'No text returned from Gemini')
-        throw new Error('No text was returned from the LLM via inference')
-      }
-
-      logger.info({ text: response.text }, 'Received response from Gemini')
-      return response.text
-    },
-
     async generateImage (options: GenerateImageOptions): Promise<Buffer> {
       const { prompt } = options
       const response = await googleGenAI.models.generateContent(

--- a/src/utils/text-generation-client.ts
+++ b/src/utils/text-generation-client.ts
@@ -1,0 +1,8 @@
+export interface TextGenerationClient {
+  prompt(options: PromptOptions): Promise<string>;
+}
+
+export interface PromptOptions {
+  systemInstruction: string | undefined;
+  prompt: string;
+}


### PR DESCRIPTION
## Summary
- Add a LangChain/Codex OAuth text client using the priority service tier.
- Move `/chat`, `/prompt`, and the deez-nuts chime-in off Gemini while keeping Gemini for image generation and remixing.
- Update Docker and Compose docs to use a persistent OAuth auth volume without baking credentials into the public image, and verify `npx` is available in the runtime image.

## Testing
- `pnpm run lint`
- `pnpm run build`
- `docker build -t slowpoke-codex-migration-test .`